### PR TITLE
drop frequency for encoding by default

### DIFF
--- a/notebooks/dichotomic_pattern_mining.ipynb
+++ b/notebooks/dichotomic_pattern_mining.ipynb
@@ -374,7 +374,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DPM finished! Runtime: 13.4088 sec\n",
+      "DPM finished! Runtime: 13.9297 sec\n",
       "Aggregation:  intersection  with number of patterns:  215\n",
       "Aggregation:  union  with number of patterns:  498\n",
       "Aggregation:  unique_negative  with number of patterns:  29\n",
@@ -421,7 +421,7 @@
      "output_type": "stream",
      "text": [
       "Aggregation:  intersection\n",
-      "Encoding finished! Runtime: 211.6533 sec\n"
+      "Encoding finished! Runtime: 212.4152 sec\n"
      ]
     },
     {
@@ -641,7 +641,7 @@
      "output_type": "stream",
      "text": [
       "Aggregation:  union\n",
-      "Encoding finished! Runtime: 408.2286 sec\n"
+      "Encoding finished! Runtime: 396.5205 sec\n"
      ]
     },
     {
@@ -861,7 +861,7 @@
      "output_type": "stream",
      "text": [
       "Aggregation:  unique_negative\n",
-      "Encoding finished! Runtime: 17.7938 sec\n"
+      "Encoding finished! Runtime: 17.2031 sec\n"
      ]
     },
     {
@@ -1074,7 +1074,7 @@
      "output_type": "stream",
      "text": [
       "Aggregation:  unique_positive\n",
-      "Encoding finished! Runtime: 178.5864 sec\n"
+      "Encoding finished! Runtime: 175.8174 sec\n"
      ]
     },
     {
@@ -1308,7 +1308,8 @@
     "    \n",
     "    t = time()\n",
     "    # find one hot encoding of each sequence for each pattern subject to constraints\n",
-    "    encodings = get_one_hot_encodings(sequences, patterns, constraints, args['rolling_window_size'])\n",
+    "    encodings = get_one_hot_encodings(sequences, patterns, constraints, args['rolling_window_size'],\n",
+    "                                      drop_pattern_frequency=False)\n",
     "    \n",
     "    print(f'Encoding finished! Runtime: {time()-t:.4f} sec')\n",
     "    display(encodings.head())"

--- a/sequential/dpm.py
+++ b/sequential/dpm.py
@@ -76,7 +76,7 @@ def dichotomic_pattern_mining(seq2pat_pos: Seq2Pat, seq2pat_neg: Seq2Pat,
 
 def get_one_hot_encodings(sequences: List[list], patterns: List[list],
                           constraints: Union[List[_Constraint], None] = None,
-                          rolling_window_size: Union[int, None] = 10, drop_pattern_frequency=False) -> pd.DataFrame:
+                          rolling_window_size: Union[int, None] = 10, drop_pattern_frequency=True) -> pd.DataFrame:
     """
     Create a data frame having one-hot encoding of sequences.
 
@@ -93,7 +93,7 @@ def get_one_hot_encodings(sequences: List[list], patterns: List[list],
         sequence subject to the pattern detection, to speed up the encodings generation.
         (rolling_window_size=10 by default). When rolling_window_size=None, patterns are detected globally.
     drop_pattern_frequency: bool
-        Drop the frequency appended in the end of each input pattern, drop_pattern_frequency=False by default.
+        Drop the frequency appended in the end of each input pattern, drop_pattern_frequency=True by default.
 
     Returns
     -------

--- a/tests/test_dpm.py
+++ b/tests/test_dpm.py
@@ -39,7 +39,7 @@ class TestDPMUtils(unittest.TestCase):
 
         # Create encoding
         encodings = get_one_hot_encodings(sequences, patterns,
-                                          constraints=[price_ct], drop_pattern_frequency=True)
+                                          constraints=[price_ct])
         # sequence      feat0
         # [A,A,B,A,D]    1
         # [C, B, A]      0
@@ -74,7 +74,7 @@ class TestDPMUtils(unittest.TestCase):
 
         # Create encoding with csp_global when rolling_window_size=None
         encodings = get_one_hot_encodings(sequences, patterns, constraints=[price_ct],
-                                          rolling_window_size=None, drop_pattern_frequency=True)
+                                          rolling_window_size=None)
         # sequence      feat0
         # [A,A,B,A,D]    1
         # [C, B, A]      0
@@ -94,7 +94,7 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding
-        encodings = get_one_hot_encodings(sequences, patterns, drop_pattern_frequency=True)
+        encodings = get_one_hot_encodings(sequences, patterns)
         # encoding is a data frame
         # sequence      feat0 feat1 feat2
         # [A,A,B,A,D]    1    1     0
@@ -115,8 +115,7 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding
-        encodings = get_one_hot_encodings(sequences, patterns, rolling_window_size=None,
-                                          drop_pattern_frequency=True)
+        encodings = get_one_hot_encodings(sequences, patterns, rolling_window_size=None)
         # encoding is a data frame
         # sequence      feat0 feat1 feat2
         # [A,A,B,A,D]    1    1     0
@@ -242,7 +241,7 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding with/without constraints
-        encodings = get_one_hot_encodings(sequences, patterns, [price_ct], drop_pattern_frequency=True)
+        encodings = get_one_hot_encodings(sequences, patterns, [price_ct])
 
         self.assertListEqual([[1], [0], [1]], encodings.values[:, 1:].tolist())
 

--- a/tests/test_dpm.py
+++ b/tests/test_dpm.py
@@ -39,7 +39,7 @@ class TestDPMUtils(unittest.TestCase):
 
         # Create encoding
         encodings = get_one_hot_encodings(sequences, patterns,
-                                          constraints=[price_ct])
+                                          constraints=[price_ct], drop_pattern_frequency=True)
         # sequence      feat0
         # [A,A,B,A,D]    1
         # [C, B, A]      0
@@ -74,7 +74,7 @@ class TestDPMUtils(unittest.TestCase):
 
         # Create encoding with csp_global when rolling_window_size=None
         encodings = get_one_hot_encodings(sequences, patterns, constraints=[price_ct],
-                                          rolling_window_size=None)
+                                          rolling_window_size=None, drop_pattern_frequency=True)
         # sequence      feat0
         # [A,A,B,A,D]    1
         # [C, B, A]      0
@@ -94,7 +94,7 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding
-        encodings = get_one_hot_encodings(sequences, patterns)
+        encodings = get_one_hot_encodings(sequences, patterns, drop_pattern_frequency=True)
         # encoding is a data frame
         # sequence      feat0 feat1 feat2
         # [A,A,B,A,D]    1    1     0
@@ -115,7 +115,8 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding
-        encodings = get_one_hot_encodings(sequences, patterns, rolling_window_size=None)
+        encodings = get_one_hot_encodings(sequences, patterns, rolling_window_size=None,
+                                          drop_pattern_frequency=True)
         # encoding is a data frame
         # sequence      feat0 feat1 feat2
         # [A,A,B,A,D]    1    1     0
@@ -241,7 +242,7 @@ class TestDPMUtils(unittest.TestCase):
         patterns = seq2pat.get_patterns(min_frequency=2)
 
         # Create encoding with/without constraints
-        encodings = get_one_hot_encodings(sequences, patterns, [price_ct])
+        encodings = get_one_hot_encodings(sequences, patterns, [price_ct], drop_pattern_frequency=True)
 
         self.assertListEqual([[1], [0], [1]], encodings.values[:, 1:].tolist())
 


### PR DESCRIPTION
This PR is for a fix on the default behavior of `drop_pattern_frequency` in encoding. Setting it to be True by default, for the ease of use when patterns mined by seq2pat are used directly for generating encodings.